### PR TITLE
Attempt to cast str to float in column headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 scmcallib
 ---------
 
+- (`#120 <https://github.com/openclimatedata/openscm/pull/120>`_) Attempt to cast str dates to float as a check for being able to be converted to datetimes
 - (`#112 <https://github.com/openclimatedata/openscm/pull/112>`_) Added demo of FaIR adapter
 - (`#88 <https://github.com/openclimatedata/openscm/pull/88>`_) Added demos of MAGICC and PH99 adapters
 - (`#103 <https://github.com/openclimatedata/openscm/pull/103>`_) Add resample method for `ScmDataFrame`

--- a/tests/integration/test_highlevel.py
+++ b/tests/integration/test_highlevel.py
@@ -53,7 +53,7 @@ def test_init_df_year_converted_to_datetime(test_pd_df):
 
 def get_test_pd_df_with_datetime_columns(tpdf):
     return tpdf.rename(
-        {2005: datetime.datetime(2005, 1, 1), 2010: datetime.datetime(2010, 1, 1)},
+        {2005.: datetime.datetime(2005, 1, 1), 2010.: datetime.datetime(2010, 1, 1)},
         axis="columns",
     )
 
@@ -79,6 +79,20 @@ def test_init_ts(test_ts, test_pd_df):
 
     pd.testing.assert_frame_equal(df.meta, b.meta, check_like=True)
     pd.testing.assert_frame_equal(df._data, b._data)
+
+
+@pytest.mark.parametrize('years', [['2005.0', '2010.0'], ['2005', '2010']])
+def test_init_with_years_as_str(test_pd_df, years):
+    df = copy.deepcopy(test_pd_df)  # This needs to be a deep copy so it doesn't break the other tests
+    cols = copy.deepcopy(test_pd_df.columns.values)
+    cols[-2:] = years
+    df.columns = cols
+
+    df = ScmDataFrame(df)
+
+    obs = df._data.index
+    exp = pd.Index([datetime.datetime(2005, 1, 1), datetime.datetime(2010, 1, 1)], name='time', dtype='object')
+    pd.testing.assert_index_equal(obs, exp)
 
 
 def test_col_order(test_scm_df):


### PR DESCRIPTION
Allows reading ScmDataFrame's straight from file if dates are provided as years. pd.read_csv keeps them as strings

- [x] Implementation finished
- [x] Tests added
- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openclimatedata/openscm/pull/XX>`_) Added feature which does something``)
