### PR TITLE
Remove non-ASCII quotes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ ignore_errors = true
 
 [pydocstyle]
 # D213 - Multi-line docstring summary should start at the second line
-# D402 - First line should not be the function’s “signature”
+# D402 - First line should not be the function’s "signature"
 add_select = D213, D402
 # D200 - One-line docstring should fit on one line with quotes
 # D205 - 1 blank line required between summary line and description


### PR DESCRIPTION
Same as #205 for the `iiasa-climate-assessment` branch. Probably needs a rebase but don't want to break anything I don't understand

- [x] Implementation finished
- [ ] Tests added
- [ ] Documentation added
- [ ] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [ ] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openclimatedata/openscm/pull/XX>`_) Added feature which does something``)
